### PR TITLE
set maven version to latest recommended version in order to remove wa…

### DIFF
--- a/assignment4/pom.xml
+++ b/assignment4/pom.xml
@@ -26,6 +26,7 @@
         <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-compiler-plugin</artifactId>
+            <version>3.6.0</version>
             <configuration>
                 <source>1.8</source>
                 <target>1.8</target>


### PR DESCRIPTION
Description Major:

This change removes the following warning when performing "mvn install". [3.6.0 is the latest recommended version.
](https://maven.apache.org/download.cgi)

[WARNING] 
[WARNING] Some problems were encountered while building the effective model for edu.gatech.cs7641:assignment4:jar:1.0
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ line 26, column 17
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING] 

Validation Notes:
- mvn install
- can still execute main with "java -cp 'target/assignment4-1.0.jar:/Users/niftynico/.m2/repository/edu/brown/cs/burlap/burlap/3.0.0/burlap-3.0.0.jar:/Users/niftynico/.m2/repository/org/apache/commons/commons-lang3/3.1/commons-lang3-3.1.jar' edu.gatech.cs7641.assignment4.Main"